### PR TITLE
Add bulk JSON Schema and Protobuf schema bundle loading

### DIFF
--- a/src/main/java/io/mapsmessaging/schemas/config/impl/JsonSchemaConfig.java
+++ b/src/main/java/io/mapsmessaging/schemas/config/impl/JsonSchemaConfig.java
@@ -19,9 +19,15 @@
  */
 package io.mapsmessaging.schemas.config.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.mapsmessaging.schemas.config.SchemaConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * The type Json schema config.
@@ -43,6 +49,15 @@ public class JsonSchemaConfig extends SchemaConfig {
   public JsonSchemaConfig(String schema) {
     super(NAME);
     setSchema(JsonParser.parseString(schema).getAsJsonObject());
+  }
+
+
+  public JsonSchemaConfig(Path schemaDirectory) throws IOException {
+    super(NAME);
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode schemaNode = objectMapper.readTree(schemaDirectory.toFile());
+    JsonObject jsonObject = JsonParser.parseString(schemaNode.toString()).getAsJsonObject();
+    setSchema(jsonObject);
   }
 
   private JsonSchemaConfig(SchemaConfig config) {

--- a/src/main/java/io/mapsmessaging/schemas/config/impl/JsonSchemaConfig.java
+++ b/src/main/java/io/mapsmessaging/schemas/config/impl/JsonSchemaConfig.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 
 /**
  * The type Json schema config.
@@ -58,6 +59,10 @@ public class JsonSchemaConfig extends SchemaConfig {
     JsonNode schemaNode = objectMapper.readTree(schemaDirectory.toFile());
     JsonObject jsonObject = JsonParser.parseString(schemaNode.toString()).getAsJsonObject();
     setSchema(jsonObject);
+    setUniqueId(UUID.nameUUIDFromBytes(schemaNode.toString().getBytes()));
+    setName(schemaDirectory.getFileName().toString());
+    setSource(schemaDirectory.toUri().toString());
+    setVersion(1);
   }
 
   private JsonSchemaConfig(SchemaConfig config) {

--- a/src/main/java/io/mapsmessaging/schemas/formatters/impl/JsonFormatter.java
+++ b/src/main/java/io/mapsmessaging/schemas/formatters/impl/JsonFormatter.java
@@ -1,21 +1,18 @@
 /*
  *
- *  Copyright [ 2020 - 2024 ] Matthew Buckton
- *  Copyright [ 2024 - 2025 ] MapsMessaging B.V.
+ *     Copyright [ 2020 - 2026 ] [Matthew Buckton]
  *
- *  Licensed under the Apache License, Version 2.0 with the Commons Clause
- *  (the "License"); you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at:
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *      https://commonsclause.com/
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 
 package io.mapsmessaging.schemas.formatters.impl;
@@ -30,7 +27,7 @@ import com.google.gson.JsonParser;
 import com.networknt.schema.Error;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.SpecificationVersion;
 import io.mapsmessaging.schemas.config.SchemaConfig;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.schemas.formatters.ParsedObject;
@@ -61,15 +58,12 @@ public class JsonFormatter extends MessageFormatter {
     schema = null;
   }
 
-
   public JsonFormatter(String schemaString) throws JsonProcessingException {
     ObjectMapper objectMapper = new ObjectMapper();
-
-    // Convert byte[] schema to JsonNode
     schemaNode = objectMapper.readTree(schemaString);
-
-    // Create JsonSchema instance
-    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft7());
+    String schemaDialect = schemaNode.path("$schema").asText(null);
+    SpecificationVersion version = SpecificationVersion.fromDialectId(schemaDialect).orElse(SpecificationVersion.DRAFT_7);
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(version);
     schema = schemaRegistry.getSchema(schemaNode);
   }
 

--- a/src/main/java/io/mapsmessaging/schemas/formatters/impl/JsonFormatter.java
+++ b/src/main/java/io/mapsmessaging/schemas/formatters/impl/JsonFormatter.java
@@ -24,10 +24,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.networknt.schema.*;
 import com.networknt.schema.Error;
-import com.networknt.schema.Schema;
-import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.SpecificationVersion;
 import io.mapsmessaging.schemas.config.SchemaConfig;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.schemas.formatters.ParsedObject;
@@ -36,6 +34,8 @@ import io.mapsmessaging.schemas.formatters.walker.StructuredResolver;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -65,6 +65,30 @@ public class JsonFormatter extends MessageFormatter {
     SpecificationVersion version = SpecificationVersion.fromDialectId(schemaDialect).orElse(SpecificationVersion.DRAFT_7);
     SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(version);
     schema = schemaRegistry.getSchema(schemaNode);
+  }
+
+  public JsonFormatter(Path schemaPath) throws IOException {
+    if (schemaPath == null) {
+      throw new IllegalArgumentException("schemaPath cannot be null");
+    }
+    if (!Files.exists(schemaPath)) {
+      throw new IOException("Schema file does not exist: " + schemaPath);
+    }
+    if (!Files.isRegularFile(schemaPath)) {
+      throw new IOException("Schema path is not a file: " + schemaPath);
+    }
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    schemaNode = objectMapper.readTree(schemaPath.toFile());
+
+    String schemaDialect = schemaNode.path("$schema").asText(null);
+    SpecificationVersion version = SpecificationVersion.fromDialectId(schemaDialect)
+        .orElse(SpecificationVersion.DRAFT_7);
+
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(version);
+    SchemaLocation location = SchemaLocation.of(schemaPath.toUri().toString());
+    schema = schemaRegistry.getSchema(location);
+    schema.initializeValidators();
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/schemas/logging/SchemaLogMessages.java
+++ b/src/main/java/io/mapsmessaging/schemas/logging/SchemaLogMessages.java
@@ -41,6 +41,7 @@ public enum SchemaLogMessages implements LogMessage {
   AVRO_PARSE_EXCEPTION(LEVEL.ERROR, SCHEMA_CATEGORY.FORMATTER, "Avro format raised exception during parsing, {}"),
   FORMATTER_UNEXPECTED_OBJECT(LEVEL.ERROR, SCHEMA_CATEGORY.FORMATTER, "{} formatter unable to parse object, unexpected data {}"),
   PROTOBUF_PARSE_EXCEPTION(LEVEL.ERROR, SCHEMA_CATEGORY.FORMATTER, "Protobuf format raised exception during parsing {}"),
+  PROTOBUF_FAILED_TO_DELETE(LEVEL.ERROR, SCHEMA_CATEGORY.CONFIG, "Failed to delete temp file {}"),
   XML_CONFIGURATION_EXCEPTION(LEVEL.ERROR, SCHEMA_CATEGORY.FORMATTER, "XML formatter raised exception during construction {}"),
   XML_PARSE_EXCEPTION(LEVEL.ERROR, SCHEMA_CATEGORY.FORMATTER, "XML formatter raised exception during parsing {}"),
   JSON_PARSE_EXCEPTION(LEVEL.ERROR, SCHEMA_CATEGORY.FORMATTER, "JSON formatter raised exception during parsing {} with the following error(s) {}"),

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/DescriptorInspector.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/DescriptorInspector.java
@@ -1,7 +1,6 @@
 /*
  *
- *  Copyright [ 2020 - 2024 ] Matthew Buckton
- *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *  Copyright [ 2026 - 2026 ] MapsMessaging B.V.
  *
  *  Licensed under the Apache License, Version 2.0 with the Commons Clause
  *  (the "License"); you may not use this file except in compliance with the License.

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/DescriptorInspector.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/DescriptorInspector.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.mapsmessaging.schemas.tools.protobuf;
+
+import com.google.protobuf.DescriptorProtos;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class DescriptorInspector {
+
+  public static void inspect(Path descriptorPath) throws IOException {
+    byte[] bytes = Files.readAllBytes(descriptorPath);
+    DescriptorProtos.FileDescriptorSet fileDescriptorSet =
+        DescriptorProtos.FileDescriptorSet.parseFrom(bytes);
+
+    System.out.println("Descriptor: " + descriptorPath);
+    System.out.println("Files in set: " + fileDescriptorSet.getFileCount());
+
+    for (DescriptorProtos.FileDescriptorProto fileDescriptor : fileDescriptorSet.getFileList()) {
+      System.out.println("File: " + fileDescriptor.getName());
+
+      for (DescriptorProtos.DescriptorProto messageType : fileDescriptor.getMessageTypeList()) {
+        System.out.println("  Message: " + messageType.getName());
+      }
+
+      for (DescriptorProtos.EnumDescriptorProto enumType : fileDescriptor.getEnumTypeList()) {
+        System.out.println("  Enum: " + enumType.getName());
+      }
+
+      for (DescriptorProtos.ServiceDescriptorProto service : fileDescriptor.getServiceList()) {
+        System.out.println("  Service: " + service.getName());
+      }
+    }
+  }
+
+
+}

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
@@ -1,0 +1,410 @@
+/*
+ *
+ *     Copyright [ 2020 - 2026 ] [Matthew Buckton]
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package io.mapsmessaging.schemas.tools.protobuf;
+
+import lombok.Getter;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.*;
+
+public class ProtoDescriptorCompiler {
+
+  private final Path configuredProtocPath;
+
+  @Getter
+  private Path resolvedProtocPath;
+
+  public ProtoDescriptorCompiler() {
+    this(null);
+  }
+
+  public ProtoDescriptorCompiler(Path configuredProtocPath) {
+    this.configuredProtocPath = configuredProtocPath;
+  }
+
+  public boolean isAvailable() {
+    try {
+      resolveProtocPath();
+      return true;
+    } catch (IOException ignored) {
+      return false;
+    }
+  }
+
+  public Path getProtocPath() throws IOException {
+    return resolveProtocPath();
+  }
+
+  public String getProtocVersion() throws IOException, InterruptedException {
+    Path protocPath = resolveProtocPath();
+
+    List<String> command = new ArrayList<>();
+    command.add(protocPath.toString());
+    command.add("--version");
+
+    ProcessResult processResult = execute(command, null);
+    if (processResult.exitCode != 0) {
+      throw new IOException("Failed to execute protoc --version\n" + processResult.output);
+    }
+    return processResult.output.trim();
+  }
+
+  public Path compile(Path rootPath, Path protoRootPath, Path descriptorOutputPath) throws IOException, InterruptedException {
+    return compile(rootPath, protoRootPath, descriptorOutputPath, List.of());
+  }
+
+  public Path compile(
+      Path rootPath,
+      Path protoRootPath,
+      Path descriptorOutputPath,
+      List<Path> additionalIncludePaths
+  ) throws IOException, InterruptedException {
+    Path normalizedRootPath = validateRootPath(rootPath);
+    Path normalizedProtoRootPath = validateProtoRootPath(protoRootPath);
+    validateProtoRootUnderRoot(normalizedRootPath, normalizedProtoRootPath);
+    validateDescriptorOutputPath(descriptorOutputPath);
+
+    List<Path> protoFiles = findProtoFilesInSingleDirectory(normalizedProtoRootPath);
+    if (protoFiles.isEmpty()) {
+      throw new IOException("No .proto files found directly under " + normalizedProtoRootPath);
+    }
+
+    Path normalizedDescriptorOutputPath = descriptorOutputPath.toAbsolutePath().normalize();
+    Path parentPath = normalizedDescriptorOutputPath.getParent();
+    if (parentPath != null) {
+      Files.createDirectories(parentPath);
+    }
+
+    List<String> command = buildCompileCommand(
+        normalizedRootPath,
+        normalizedDescriptorOutputPath,
+        protoFiles,
+        additionalIncludePaths
+    );
+
+    ProcessResult processResult = execute(command, normalizedRootPath);
+    if (processResult.exitCode != 0) {
+      throw new IOException(
+          "protoc failed with exit code " + processResult.exitCode + "\n" + processResult.output
+      );
+    }
+
+    if (!Files.exists(normalizedDescriptorOutputPath) || Files.size(normalizedDescriptorOutputPath) == 0) {
+      throw new IOException("Descriptor output file was not created: " + normalizedDescriptorOutputPath);
+    }
+
+    return normalizedDescriptorOutputPath;
+  }
+
+  public Path compileIfRequired(
+      Path rootPath,
+      Path protoRootPath,
+      Path descriptorOutputPath,
+      List<Path> additionalIncludePaths
+  ) throws IOException, InterruptedException {
+    Path normalizedRootPath = validateRootPath(rootPath);
+    Path normalizedProtoRootPath = validateProtoRootPath(protoRootPath);
+    validateProtoRootUnderRoot(normalizedRootPath, normalizedProtoRootPath);
+    validateDescriptorOutputPath(descriptorOutputPath);
+
+    List<Path> protoFiles = findProtoFilesInSingleDirectory(normalizedProtoRootPath);
+    if (protoFiles.isEmpty()) {
+      throw new IOException("No .proto files found directly under " + normalizedProtoRootPath);
+    }
+
+    Path normalizedDescriptorOutputPath = descriptorOutputPath.toAbsolutePath().normalize();
+    if (!needsRebuild(protoFiles, normalizedDescriptorOutputPath)) {
+      return normalizedDescriptorOutputPath;
+    }
+
+    return compile(normalizedRootPath, normalizedProtoRootPath, normalizedDescriptorOutputPath, additionalIncludePaths);
+  }
+
+  public List<Path> compileAllUnderRoot(Path rootPath, Path outputDirectoryPath) throws IOException, InterruptedException {
+    return compileAllUnderRoot(rootPath, outputDirectoryPath, List.of());
+  }
+
+  public List<Path> compileAllUnderRoot(
+      Path rootPath,
+      Path outputDirectoryPath,
+      List<Path> additionalIncludePaths
+  ) throws IOException, InterruptedException {
+    Path normalizedRootPath = validateRootPath(rootPath);
+    Objects.requireNonNull(outputDirectoryPath, "outputDirectoryPath must not be null");
+
+    Path normalizedOutputDirectoryPath = outputDirectoryPath.toAbsolutePath().normalize();
+    Files.createDirectories(normalizedOutputDirectoryPath);
+
+    List<Path> schemaDirectories = findProtoDirectories(normalizedRootPath);
+    if (schemaDirectories.isEmpty()) {
+      throw new IOException("No directories containing .proto files found under " + normalizedRootPath);
+    }
+
+    List<Path> descriptorPaths = new ArrayList<>();
+    for (Path schemaDirectory : schemaDirectories) {
+      Path relativeDirectory = normalizedRootPath.relativize(schemaDirectory);
+
+      String descriptorFileName;
+      if (relativeDirectory.getNameCount() == 0) {
+        descriptorFileName = "root.desc";
+      } else {
+        descriptorFileName = relativeDirectory.toString().replace('\\', '_').replace('/', '_') + ".desc";
+      }
+
+      Path descriptorOutputPath = normalizedOutputDirectoryPath.resolve(descriptorFileName);
+      Path compiledPath = compileIfRequired(normalizedRootPath, schemaDirectory, descriptorOutputPath, additionalIncludePaths);
+      descriptorPaths.add(compiledPath);
+    }
+
+    descriptorPaths.sort(Comparator.comparing(path -> path.toAbsolutePath().toString()));
+    return descriptorPaths;
+  }
+
+  public List<Path> findProtoDirectories(Path rootPath) throws IOException {
+    Path normalizedRootPath = validateRootPath(rootPath);
+
+    Set<Path> directories = new LinkedHashSet<>();
+
+    Files.walkFileTree(normalizedRootPath, new SimpleFileVisitor<>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+        if (attributes.isRegularFile() && file.getFileName().toString().endsWith(".proto")) {
+          directories.add(file.getParent().toAbsolutePath().normalize());
+        }
+        return FileVisitResult.CONTINUE;
+      }
+    });
+
+    List<Path> results = new ArrayList<>(directories);
+    results.sort(Comparator.comparing(path -> path.toAbsolutePath().toString()));
+    return results;
+  }
+
+  private List<String> buildCompileCommand(
+      Path rootPath,
+      Path descriptorOutputPath,
+      List<Path> protoFiles,
+      List<Path> additionalIncludePaths
+  ) throws IOException {
+    Path protocPath = resolveProtocPath();
+
+    List<String> command = new ArrayList<>();
+    command.add(protocPath.toString());
+
+    command.add("-I");
+    command.add(rootPath.toString());
+
+    if (additionalIncludePaths != null) {
+      for (Path includePath : additionalIncludePaths) {
+        if (includePath != null) {
+          command.add("-I");
+          command.add(includePath.toAbsolutePath().normalize().toString());
+        }
+      }
+    }
+
+    command.add("--include_imports");
+    command.add("--descriptor_set_out=" + descriptorOutputPath);
+
+    for (Path protoFile : protoFiles) {
+      Path normalizedProtoFile = protoFile.toAbsolutePath().normalize();
+      if (!normalizedProtoFile.startsWith(rootPath)) {
+        throw new IOException("Proto file is outside root path: " + normalizedProtoFile);
+      }
+      command.add(rootPath.relativize(normalizedProtoFile).toString());
+    }
+
+    return command;
+  }
+
+  private ProcessResult execute(List<String> command, Path workingDirectory) throws IOException, InterruptedException {
+    ProcessBuilder processBuilder = new ProcessBuilder(command);
+    processBuilder.redirectErrorStream(true);
+
+    if (workingDirectory != null) {
+      processBuilder.directory(workingDirectory.toFile());
+    }
+
+    Process process = processBuilder.start();
+    String output = readProcessOutput(process);
+    int exitCode = process.waitFor();
+
+    return new ProcessResult(exitCode, output);
+  }
+
+  private String readProcessOutput(Process process) throws IOException {
+    StringBuilder stringBuilder = new StringBuilder();
+
+    try (BufferedReader bufferedReader = new BufferedReader(
+        new InputStreamReader(process.getInputStream())
+    )) {
+      String line;
+      while ((line = bufferedReader.readLine()) != null) {
+        stringBuilder.append(line).append(System.lineSeparator());
+      }
+    }
+
+    return stringBuilder.toString();
+  }
+
+  private List<Path> findProtoFilesInSingleDirectory(Path protoDirectoryPath) throws IOException {
+    List<Path> protoFiles = new ArrayList<>();
+
+    try (var stream = Files.list(protoDirectoryPath)) {
+      stream.filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".proto"))
+          .map(path -> path.toAbsolutePath().normalize())
+          .sorted(Comparator.comparing(path -> path.toAbsolutePath().toString()))
+          .forEach(protoFiles::add);
+    }
+
+    return protoFiles;
+  }
+
+  private boolean needsRebuild(List<Path> protoFiles, Path descriptorOutputPath) throws IOException {
+    if (!Files.exists(descriptorOutputPath)) {
+      return true;
+    }
+
+    Instant descriptorModifiedTime = Files.getLastModifiedTime(descriptorOutputPath).toInstant();
+    for (Path protoFile : protoFiles) {
+      Instant protoModifiedTime = Files.getLastModifiedTime(protoFile).toInstant();
+      if (protoModifiedTime.isAfter(descriptorModifiedTime)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Path resolveProtocPath() throws IOException {
+    if (resolvedProtocPath != null) {
+      return resolvedProtocPath;
+    }
+
+    if (configuredProtocPath != null) {
+      Path absoluteConfiguredPath = configuredProtocPath.toAbsolutePath().normalize();
+      validateExecutable(absoluteConfiguredPath, "Configured protoc path");
+      resolvedProtocPath = absoluteConfiguredPath;
+      return resolvedProtocPath;
+    }
+
+    Path pathResolved = resolveFromPath();
+    if (pathResolved != null) {
+      resolvedProtocPath = pathResolved;
+      return resolvedProtocPath;
+    }
+
+    throw new IOException(
+        "Unable to locate protoc. Configure an explicit path or ensure protoc is available on PATH."
+    );
+  }
+
+  private Path resolveFromPath() {
+    String pathEnvironment = System.getenv("PATH");
+    if (pathEnvironment == null || pathEnvironment.isBlank()) {
+      return null;
+    }
+
+    String executableName = isWindows() ? "protoc.exe" : "protoc";
+
+    for (String pathEntry : pathEnvironment.split(File.pathSeparator)) {
+      if (pathEntry == null || pathEntry.isBlank()) {
+        continue;
+      }
+
+      Path candidatePath = Paths.get(pathEntry, executableName).toAbsolutePath().normalize();
+      if (Files.exists(candidatePath) && Files.isRegularFile(candidatePath) && Files.isExecutable(candidatePath)) {
+        return candidatePath;
+      }
+    }
+
+    return null;
+  }
+
+  private Path validateRootPath(Path rootPath) throws IOException {
+    Objects.requireNonNull(rootPath, "rootPath must not be null");
+
+    Path normalizedRootPath = rootPath.toAbsolutePath().normalize();
+    if (!Files.exists(normalizedRootPath)) {
+      throw new IOException("Root path does not exist: " + normalizedRootPath);
+    }
+    if (!Files.isDirectory(normalizedRootPath)) {
+      throw new IOException("Root path is not a directory: " + normalizedRootPath);
+    }
+
+    return normalizedRootPath;
+  }
+
+  private Path validateProtoRootPath(Path protoRootPath) throws IOException {
+    Objects.requireNonNull(protoRootPath, "protoRootPath must not be null");
+
+    Path normalizedProtoRootPath = protoRootPath.toAbsolutePath().normalize();
+    if (!Files.exists(normalizedProtoRootPath)) {
+      throw new IOException("Proto root path does not exist: " + normalizedProtoRootPath);
+    }
+    if (!Files.isDirectory(normalizedProtoRootPath)) {
+      throw new IOException("Proto root path is not a directory: " + normalizedProtoRootPath);
+    }
+
+    return normalizedProtoRootPath;
+  }
+
+  private void validateProtoRootUnderRoot(Path rootPath, Path protoRootPath) throws IOException {
+    if (!protoRootPath.startsWith(rootPath)) {
+      throw new IOException("Proto root path must be under root path: protoRootPath=" + protoRootPath + ", rootPath=" + rootPath);
+    }
+  }
+
+  private void validateDescriptorOutputPath(Path descriptorOutputPath) {
+    Objects.requireNonNull(descriptorOutputPath, "descriptorOutputPath must not be null");
+  }
+
+  private void validateExecutable(Path executablePath, String description) throws IOException {
+    if (!Files.exists(executablePath)) {
+      throw new IOException(description + " does not exist: " + executablePath);
+    }
+    if (!Files.isRegularFile(executablePath)) {
+      throw new IOException(description + " is not a file: " + executablePath);
+    }
+    if (!Files.isExecutable(executablePath)) {
+      throw new IOException(description + " is not executable: " + executablePath);
+    }
+  }
+
+  private boolean isWindows() {
+    String operatingSystemName = System.getProperty("os.name", "");
+    return operatingSystemName.toLowerCase().contains("win");
+  }
+
+  private static final class ProcessResult {
+
+    private final int exitCode;
+    private final String output;
+
+    private ProcessResult(int exitCode, String output) {
+      this.exitCode = exitCode;
+      this.output = output;
+    }
+  }
+}

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
@@ -1,18 +1,20 @@
 /*
  *
- *     Copyright [ 2020 - 2026 ] [Matthew Buckton]
+ *  Copyright [ 2026 - 2026 ] MapsMessaging B.V.
  *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
  */
 
 package io.mapsmessaging.schemas.tools.protobuf;
@@ -106,9 +108,7 @@ public class ProtoDescriptorCompiler {
 
     ProcessResult processResult = execute(command, normalizedRootPath);
     if (processResult.exitCode != 0) {
-      throw new IOException(
-          "protoc failed with exit code " + processResult.exitCode + "\n" + processResult.output
-      );
+      throw new IOException("protoc failed with exit code " + processResult.exitCode + "\n" + processResult.output);
     }
 
     if (!Files.exists(normalizedDescriptorOutputPath) || Files.size(normalizedDescriptorOutputPath) == 0) {

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
@@ -98,6 +98,7 @@ public class ProtoDescriptorCompiler {
 
     List<String> command = buildCompileCommand(
         normalizedRootPath,
+        normalizedProtoRootPath,
         normalizedDescriptorOutputPath,
         protoFiles,
         additionalIncludePaths
@@ -203,17 +204,26 @@ public class ProtoDescriptorCompiler {
 
   private List<String> buildCompileCommand(
       Path rootPath,
+      Path protoRootPath,
       Path descriptorOutputPath,
       List<Path> protoFiles,
       List<Path> additionalIncludePaths
   ) throws IOException {
     Path protocPath = resolveProtocPath();
 
+    Path normalizedRootPath = rootPath.toAbsolutePath().normalize();
+    Path normalizedProtoRootPath = protoRootPath.toAbsolutePath().normalize();
+
     List<String> command = new ArrayList<>();
     command.add(protocPath.toString());
 
     command.add("-I");
-    command.add(rootPath.toString());
+    command.add(normalizedRootPath.toString());
+
+    if (!normalizedProtoRootPath.equals(normalizedRootPath)) {
+      command.add("-I");
+      command.add(normalizedProtoRootPath.toString());
+    }
 
     if (additionalIncludePaths != null) {
       for (Path includePath : additionalIncludePaths) {
@@ -225,14 +235,19 @@ public class ProtoDescriptorCompiler {
     }
 
     command.add("--include_imports");
-    command.add("--descriptor_set_out=" + descriptorOutputPath);
+    command.add("--descriptor_set_out=" + descriptorOutputPath.toAbsolutePath().normalize());
 
     for (Path protoFile : protoFiles) {
       Path normalizedProtoFile = protoFile.toAbsolutePath().normalize();
-      if (!normalizedProtoFile.startsWith(rootPath)) {
+      if (!normalizedProtoFile.startsWith(normalizedRootPath)) {
         throw new IOException("Proto file is outside root path: " + normalizedProtoFile);
       }
-      command.add(rootPath.relativize(normalizedProtoFile).toString());
+
+      String relativeProtoPath = normalizedRootPath.relativize(normalizedProtoFile)
+          .toString()
+          .replace('\\', '/');
+
+      command.add(relativeProtoPath);
     }
 
     return command;
@@ -329,7 +344,7 @@ public class ProtoDescriptorCompiler {
     String executableName = isWindows() ? "protoc.exe" : "protoc";
 
     for (String pathEntry : pathEnvironment.split(File.pathSeparator)) {
-      if (pathEntry == null || pathEntry.isBlank()) {
+      if (pathEntry.isBlank()) {
         continue;
       }
 

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompiler.java
@@ -329,10 +329,7 @@ public class ProtoDescriptorCompiler {
       resolvedProtocPath = pathResolved;
       return resolvedProtocPath;
     }
-
-    throw new IOException(
-        "Unable to locate protoc. Configure an explicit path or ensure protoc is available on PATH."
-    );
+    throw new IOException("Unable to locate protoc. Configure an explicit path or ensure protoc is available on PATH.");
   }
 
   private Path resolveFromPath() {

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtobufSchemaGenerator.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtobufSchemaGenerator.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.mapsmessaging.schemas.tools.protobuf;
+
+import io.mapsmessaging.logging.Logger;
+import io.mapsmessaging.logging.LoggerFactory;
+import io.mapsmessaging.schemas.config.impl.ProtoBufSchemaConfig;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.mapsmessaging.schemas.logging.SchemaLogMessages.PROTOBUF_FAILED_TO_DELETE;
+import static io.mapsmessaging.schemas.logging.SchemaLogMessages.PROTOBUF_PARSE_EXCEPTION;
+
+public class ProtobufSchemaGenerator {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProtobufSchemaGenerator.class);
+
+  public static List<ProtoBufSchemaConfig> loadSchemas(Path rootPath, Path protocCommandPath) throws IOException {
+    Path tempDir = Files.createTempDirectory("proto-desc-" + System.nanoTime());
+    try {
+      ProtoDescriptorCompiler generator = new ProtoDescriptorCompiler(protocCommandPath);
+      try {
+        generator.compileAllUnderRoot(rootPath, tempDir);
+        return loadDescriptors(tempDir);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while compiling protobuf", e);
+      }
+    } finally {
+      deleteDirectory(tempDir);
+    }
+  }
+
+
+  private static List<ProtoBufSchemaConfig> loadDescriptors(Path outputPath) throws IOException {
+    List<ProtoBufSchemaConfig> configs = new ArrayList<>();
+
+    try (Stream<Path> stream = Files.walk(outputPath)) {
+      stream
+          .filter(Files::isRegularFile)
+          .filter(path -> path.toString().endsWith(".desc"))
+          .forEach(path -> {
+            try {
+              byte[] descriptorBytes = Files.readAllBytes(path);
+              ProtoBufSchemaConfig config = new ProtoBufSchemaConfig();
+              ProtoBufSchemaConfig.ProtobufConfig protobufConfig = new ProtoBufSchemaConfig.ProtobufConfig();
+              protobufConfig.setDescriptorValue(descriptorBytes);
+              config.setName(path.getFileName().toString());
+              config.setUniqueId(UUID.nameUUIDFromBytes(config.getName().getBytes()));
+              config.setVersion(1);
+              config.setSource(path.toString());
+              // use file name (without extension) as a reasonable default
+              String fileName = path.getFileName().toString();
+              int idx = fileName.lastIndexOf('.');
+              protobufConfig.setMessageName(idx > 0 ? fileName.substring(0, idx) : fileName);
+              config.setProtobufConfig(protobufConfig);
+              configs.add(config);
+            } catch (IOException e) {
+              logger.log(PROTOBUF_PARSE_EXCEPTION, path.toString(), e);
+            }
+          });
+    }
+    return configs;
+  }
+
+  private static void deleteDirectory(Path directory) throws IOException {
+    if (directory == null || !Files.exists(directory)) {
+      return;
+    }
+
+    try (Stream<Path> stream = Files.walk(directory)) {
+      stream.sorted(Comparator.reverseOrder())
+          .forEach(path -> {
+            try {
+              Files.deleteIfExists(path);
+            } catch (IOException e) {
+              logger.log(PROTOBUF_FAILED_TO_DELETE, path.toString(), e);
+            }
+          });
+    }
+  }
+
+  private ProtobufSchemaGenerator() {
+  }
+
+}

--- a/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtobufSchemaGenerator.java
+++ b/src/main/java/io/mapsmessaging/schemas/tools/protobuf/ProtobufSchemaGenerator.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright [ 2020 - 2024 ] Matthew Buckton
  *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
  *
  *  Licensed under the Apache License, Version 2.0 with the Commons Clause

--- a/src/test/java/io/mapsmessaging/schemas/config/JsonSchemaConfigTest.java
+++ b/src/test/java/io/mapsmessaging/schemas/config/JsonSchemaConfigTest.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Copyright [ 2020 - 2026 ] [Matthew Buckton]
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.mapsmessaging.schemas.config;
+
+import com.google.gson.JsonObject;
+import io.mapsmessaging.schemas.config.impl.JsonSchemaConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonSchemaConfigTest {
+
+  @TempDir
+  Path tempDirectory;
+
+  @Test
+  void pathConstructorLoadsSchemaAndPreservesRef() throws Exception {
+    Path schemaFile = tempDirectory.resolve("schema.json");
+
+    Files.writeString(schemaFile, """
+        {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$ref": "#/$defs/Person",
+          "$defs": {
+            "Person": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": ["name"]
+            }
+          }
+        }
+        """);
+
+    JsonSchemaConfig config = new JsonSchemaConfig(schemaFile);
+
+    JsonObject schema = config.getSchema();
+    assertNotNull(schema);
+    assertEquals("schema.json", config.getName());
+    assertEquals("application/json", config.getMimeType());
+
+    assertTrue(schema.has("$ref"));
+    assertEquals("#/$defs/Person", schema.get("$ref").getAsString());
+
+    assertTrue(schema.has("$defs"));
+    JsonObject defs = schema.getAsJsonObject("$defs");
+    assertTrue(defs.has("Person"));
+
+    JsonObject person = defs.getAsJsonObject("Person");
+    assertEquals("object", person.get("type").getAsString());
+    assertTrue(person.has("properties"));
+    assertTrue(person.has("required"));
+  }
+}

--- a/src/test/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompilerTest.java
+++ b/src/test/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompilerTest.java
@@ -1,0 +1,194 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ *
+ *     Copyright [ 2020 - 2026 ] [Matthew Buckton]
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package io.mapsmessaging.schemas.tools.protobuf;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProtoDescriptorCompilerTest {
+
+  @TempDir
+  Path tempDirectory;
+
+  @Test
+  void getProtocVersionReturnsConfiguredVersion() throws Exception {
+    Path scriptDirectory = Files.createDirectories(tempDirectory.resolve("script"));
+    Path logFile = scriptDirectory.resolve("protoc.log");
+    Path fakeProtoc = createFakeProtoc(scriptDirectory, logFile);
+
+    ProtoDescriptorCompiler compiler = new ProtoDescriptorCompiler(fakeProtoc);
+
+    String version = compiler.getProtocVersion();
+
+    assertEquals("libprotoc 99.0", version);
+  }
+
+  @Test
+  void compileAllUnderRootCreatesDescriptorPerProtoDirectory() throws Exception {
+    Path rootPath = Files.createDirectories(tempDirectory.resolve("schemas"));
+    createProtoFile(rootPath.resolve("base/authority.proto"), "Authority");
+    createProtoFile(rootPath.resolve("base/node/general.proto"), "General");
+    createProtoFile(rootPath.resolve("base/task/task.proto"), "Task");
+    createProtoFile(rootPath.resolve("catl/hibw/core/core.proto"), "Core");
+    createProtoFile(rootPath.resolve("catl/hibw/messages/message.proto"), "Message");
+
+    Path outputDirectoryPath = Files.createDirectories(tempDirectory.resolve("out"));
+    Path scriptDirectory = Files.createDirectories(tempDirectory.resolve("script"));
+    Path logFile = scriptDirectory.resolve("protoc.log");
+    Path fakeProtoc = createFakeProtoc(scriptDirectory, logFile);
+
+    ProtoDescriptorCompiler compiler = new ProtoDescriptorCompiler(fakeProtoc);
+
+    List<Path> compiled = compiler.compileAllUnderRoot(rootPath, outputDirectoryPath);
+
+    assertEquals(5, compiled.size());
+    assertTrue(Files.exists(outputDirectoryPath.resolve("base.desc")));
+    assertTrue(Files.exists(outputDirectoryPath.resolve("base_node.desc")));
+    assertTrue(Files.exists(outputDirectoryPath.resolve("base_task.desc")));
+    assertTrue(Files.exists(outputDirectoryPath.resolve("catl_hibw_core.desc")));
+    assertTrue(Files.exists(outputDirectoryPath.resolve("catl_hibw_messages.desc")));
+
+    for (Path path : compiled) {
+      assertTrue(Files.exists(path));
+      assertTrue(Files.size(path) > 0);
+    }
+  }
+
+  @Test
+  void compileIfRequiredSkipsRebuildWhenDescriptorIsNewer() throws Exception {
+    Path rootPath = Files.createDirectories(tempDirectory.resolve("schemas"));
+    Path protoDirectoryPath = Files.createDirectories(rootPath.resolve("base"));
+    createProtoFile(protoDirectoryPath.resolve("authority.proto"), "Authority");
+
+    Path outputDirectoryPath = Files.createDirectories(tempDirectory.resolve("out"));
+    Path descriptorOutputPath = outputDirectoryPath.resolve("base.desc");
+
+    Path scriptDirectory = Files.createDirectories(tempDirectory.resolve("script"));
+    Path logFile = scriptDirectory.resolve("protoc.log");
+    Path fakeProtoc = createFakeProtoc(scriptDirectory, logFile);
+
+    ProtoDescriptorCompiler compiler = new ProtoDescriptorCompiler(fakeProtoc);
+
+    Path firstCompile = compiler.compile(rootPath, protoDirectoryPath, descriptorOutputPath);
+    long initialLogLineCount = countLines(logFile);
+
+    Files.setLastModifiedTime(firstCompile, FileTime.from(Instant.now().plusSeconds(60)));
+
+    Path secondCompile = compiler.compileIfRequired(rootPath, protoDirectoryPath, descriptorOutputPath, List.of());
+    long finalLogLineCount = countLines(logFile);
+
+    assertEquals(firstCompile, secondCompile);
+    assertEquals(initialLogLineCount, finalLogLineCount);
+  }
+
+  private void createProtoFile(Path path, String messageName) throws IOException {
+    Files.createDirectories(path.getParent());
+    Files.writeString(
+        path,
+        "syntax = \"proto3\";\n" +
+            "package test;\n" +
+            "message " + messageName + " {\n" +
+            "  string value = 1;\n" +
+            "}\n"
+    );
+  }
+
+  private long countLines(Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return 0;
+    }
+    try (var stream = Files.lines(path)) {
+      return stream.count();
+    }
+  }
+
+  private Path createFakeProtoc(Path scriptDirectory, Path logFile) throws IOException {
+    Path scriptPath = scriptDirectory.resolve("protoc.cmd");
+    String script =
+        "@echo off\r\n" +
+            "setlocal EnableDelayedExpansion\r\n" +
+            "set \"LOGFILE=" + logFile.toString() + "\"\r\n" +
+            "if \"%~1\"==\"--version\" (\r\n" +
+            "  echo libprotoc 99.0\r\n" +
+            "  exit /b 0\r\n" +
+            ")\r\n" +
+            "set \"OUTFILE=\"\r\n" +
+            ":loop\r\n" +
+            "if \"%~1\"==\"\" goto done\r\n" +
+            "echo %~1>>\"%LOGFILE%\"\r\n" +
+            "if /I \"%~1\"==\"--descriptor_set_out\" (\r\n" +
+            "  set \"OUTFILE=%~2\"\r\n" +
+            "  echo OUTFILE=!OUTFILE!>>\"%LOGFILE%\"\r\n" +
+            "  shift\r\n" +
+            "  shift\r\n" +
+            "  goto loop\r\n" +
+            ")\r\n" +
+            "shift\r\n" +
+            "goto loop\r\n" +
+            ":done\r\n" +
+            "if \"!OUTFILE!\"==\"\" exit /b 1\r\n" +
+            "echo fake descriptor>\"!OUTFILE!\"\r\n" +
+            "if not exist \"!OUTFILE!\" exit /b 2\r\n" +
+            "exit /b 0\r\n";
+    Files.writeString(scriptPath, script);
+    return scriptPath;
+  }
+
+  private boolean isWindows() {
+    String operatingSystemName = System.getProperty("os.name", "");
+    return operatingSystemName.toLowerCase().contains("win");
+  }
+
+  private String escapeForShell(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  private String quoteForBatch(String value) {
+    return "\"" + value + "\"";
+  }
+}

--- a/src/test/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompilerTest.java
+++ b/src/test/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompilerTest.java
@@ -1,7 +1,6 @@
 /*
  *
- *  Copyright [ 2020 - 2024 ] Matthew Buckton
- *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *  Copyright [ 2026 - 2026 ] MapsMessaging B.V.
  *
  *  Licensed under the Apache License, Version 2.0 with the Commons Clause
  *  (the "License"); you may not use this file except in compliance with the License.
@@ -16,23 +15,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- */
-
-/*
- *
- *     Copyright [ 2020 - 2026 ] [Matthew Buckton]
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
  */
 
 package io.mapsmessaging.schemas.tools.protobuf;

--- a/src/test/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompilerTest.java
+++ b/src/test/java/io/mapsmessaging/schemas/tools/protobuf/ProtoDescriptorCompilerTest.java
@@ -161,16 +161,4 @@ class ProtoDescriptorCompilerTest {
     return scriptPath;
   }
 
-  private boolean isWindows() {
-    String operatingSystemName = System.getProperty("os.name", "");
-    return operatingSystemName.toLowerCase().contains("win");
-  }
-
-  private String escapeForShell(String value) {
-    return value.replace("\\", "\\\\").replace("\"", "\\\"");
-  }
-
-  private String quoteForBatch(String value) {
-    return "\"" + value + "\"";
-  }
 }


### PR DESCRIPTION
Pull Request Summary

This change adds support for loading schema bundles from both JSON Schema and Protocol Buffers, with the work split cleanly between:

config objects, which remain portable and self-contained

parser logic, which performs runtime lookup, validation, and payload read/write

The goal is to support bulk schema loading while keeping schema configuration easy to serialize, transport, and reuse across servers.

What changed
JSON Schema

Added support for loading JSON Schemas from a Path

Schema files are loaded into a single in-memory schema object using Jackson JsonNode

Existing config storage continues to use Gson JsonObject, with conversion from JsonNode

This allows a single JSON schema bundle to contain multiple definitions for parser lookup

Protocol Buffers

Added support for compiling .proto sources into .desc descriptor files using protoc

protoc path can be provided explicitly, or resolved from the system PATH

Added support for compiling one descriptor per schema directory under a root path

Descriptor files are generated in a temporary output directory and then loaded into schema config objects

Temporary compile output is cleaned up after loading

Descriptor compilation

Added/expanded ProtoDescriptorCompiler to:

resolve protoc

compile a specific proto directory

compile all proto-containing directories under a root

detect rebuild requirements

validate input/output paths

Descriptor output now matches the directory-oriented schema bundle model rather than producing a single monolithic descriptor set

Descriptor loading

Added logic to walk an output directory, find all .desc files, and load them into ProtoBufSchemaConfig

Each descriptor file becomes a schema bundle entry keyed by descriptor file name / relative logical bundle name

Design direction

This work aligns schema handling around a bundle model:

JSON Schema: one bundle may contain many $defs

Protobuf: one descriptor bundle may contain many message definitions

At runtime, parsers will use a two-stage lookup model:

select the schema bundle

select the schema/message definition within that bundle

This keeps the config layer portable while allowing parsers to support large schema sets efficiently.

Why this change

Previously, schema handling was more naturally aligned to a single schema per config model.

That does not scale for:

large JSON schema collections

directory-based protobuf schema trees

environments with hundreds of message formats

This change lays the groundwork for:

bulk schema import

bundle-based schema distribution between servers

runtime schema selection by key

future multi-format schema registry support

Notes

Protobuf compilation now targets one descriptor per directory under the schema root

Temporary descriptor output is explicitly deleted after loading

Path handling around protoc was tightened, especially for Windows path behaviour

This PR focuses on schema loading/config preparation. Parser expansion for multi-schema runtime lookup is the next ste